### PR TITLE
Create dotnet.yml Defining NuGet Pack and Publish Actions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -30,6 +30,6 @@ jobs:
         source-url: https://nuget.pkg.github.com/ChaplinMarchais/index.json
       env:
         NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      if: ${{ steps.Pack.Outcome == success }}
+      if: ${{ steps.Pack.Outcome == 'success' }}
     - name: Push pkg
       run: dotnet nuget push src/IGT.SwaggerUI.AspNetCore.OData/bin/Release/*.nupkg

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -20,11 +20,11 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build ${{env.CSPROJ_RELATIVE_PATH}} -c Release --no-restore
+      run: dotnet build $env.SLN_ROOT -c Release --no-restore
     - name: Test
-      run: dotnet test ${{env.SLN_ROOT}} --no-build --verbosity normal
+      run: dotnet test $env.SLN_ROOT --no-build --verbosity normal
     - name: Pack
-      run: dotnet pack ${{env.CSPROJ_RELATIVE_PATH}} -c Release -v
+      run: dotnet pack $env.CSPROJ_RELATIVE_PATH -c Release -v
     - name: Publish
       uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,35 @@
+name: Build and Publish NuGet Package
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Build Env
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build -c Release --no-restore
+    - name: Test
+      run: dotnet test --no-build --verbosity normal
+    - name: Pack
+      run: dotnet pack -c Release -v
+    - name: Publish
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.x
+        source-url: https://nuget.pkg.github.com/ChaplinMarchais/index.json
+      env:
+        NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      if: ${{ steps.Pack.Outcome == success }}
+    - name: Push pkg
+      run: dotnet nuget push src/IGT.SwaggerUI.AspNetCore.OData/bin/Release/*.nupkg

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -8,7 +8,9 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
+    env:
+      CSPROJ_RELATIVE_PATH: "src/IGT.SwaggerUI.AspNetCore.OData/*.csproj"
+      SLN_ROOT: "src/*.sln"
     steps:
     - uses: actions/checkout@v2
     - name: Setup Build Env
@@ -18,11 +20,11 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build -c Release --no-restore
+      run: dotnet build ${{env.CSPROJ_RELATIVE_PATH}} -c Release --no-restore
     - name: Test
-      run: dotnet test --no-build --verbosity normal
+      run: dotnet test ${{env.SLN_ROOT}} --no-build --verbosity normal
     - name: Pack
-      run: dotnet pack -c Release -v
+      run: dotnet pack ${{env.CSPROJ_RELATIVE_PATH}} -c Release -v
     - name: Publish
       uses: actions/setup-dotnet@v1
       with:


### PR DESCRIPTION
### Completed #4 

This commit adds the required yaml file for creating the github actions definition to trigger whenever a new PR is accepted into the main branch, which builds, tests, packs and then publishes the library to GitHub packages (assuming that the Pack and Test operations pass successfully) 